### PR TITLE
Add Presentation Support

### DIFF
--- a/PSGSuite/Public/Slides/Edit-GSPresentation.ps1
+++ b/PSGSuite/Public/Slides/Edit-GSPresentation.ps1
@@ -1,0 +1,97 @@
+function Edit-GSPresentation {
+    <#
+    .SYNOPSIS
+    Updates a Presentation
+
+    .DESCRIPTION
+    Updates a Presentation. Accepts update requests created by New-GSPresentationUpdateRequest
+
+    .PARAMETER Update
+    The update requests, as created by New-GSPresentationUpdateRequest. Can either be passed as a list of updates, or updates can piped into the command
+
+    .PARAMETER User
+    The primary email of the user that had at least Edit rights to the target Sheet
+
+    Defaults to the AdminEmail user
+
+    .PARAMETER Launch
+    If $true, opens the Presentation Url in your default browser
+
+    .INPUTS
+    Google.Apis.Slides.v1.Data.Request, created by New-GSPresentationUpdateRequest
+
+    .OUTPUTS
+    Google.Apis.Slides.v1.Data.BatchUpdatePresentationResponse
+    Information about the response is availabe here: https://developers.google.com/slides/reference/rest/v1/presentations/batchUpdate#response-body
+    The Replies Property will be a List of Google.Apis.Slides.v1.Data.Response, in the same order as the submitted requests
+
+    .EXAMPLE
+    $newSlide = New-GSSlideUpdateRequest -RequestType CreateSlide -RequestProperties @{}
+    $newSlide | Edit-GSPresentation -PresentationID $ID #Will add one new slide at the end of the Presentation
+    Edit-GSPresentation -PresentationID $ID -Update $newSlide,$newSlide #Will execute the newslide request twice, adding two new slides to the end of the Presentation
+
+    #>
+    [OutputType('Google.Apis.Slides.v1.Data.BatchUpdatePresentationResponse')]
+    [cmdletbinding()]
+    Param
+    (
+        [parameter(Mandatory = $true, Position = 0)]
+        [String]
+        $PresentationId,
+        [parameter(Mandatory = $true, Position = 1, ValueFromPipeline = $true)]
+        [System.Collections.Generic.List[Google.Apis.Slides.v1.Data.Request]]
+        $Update,
+        [parameter(Mandatory = $false)]
+        [Alias('Owner', 'PrimaryEmail', 'UserKey', 'Mail')]
+        [string]
+        $User = $Script:PSGSuite.AdminEmail,
+        [parameter(Mandatory = $false)]
+        [Alias('Open')]
+        [Switch]
+        $Launch
+    )
+    Begin {
+        if ($User -ceq 'me') {
+            $User = $Script:PSGSuite.AdminEmail
+        } elseif ($User -notlike "*@*.*") {
+            $User = "$($User)@$($Script:PSGSuite.Domain)"
+        }
+        $serviceParams = @{
+            Scope       = 'https://www.googleapis.com/auth/drive'
+            ServiceType = 'Google.Apis.Slides.v1.SlidesService'
+            User        = $User
+        }
+        $service = New-GoogleService @serviceParams
+
+        [System.Collections.Generic.List[Google.Apis.Slides.v1.Data.Request]]$requests = @()
+
+        $body = New-Object 'Google.Apis.Slides.v1.Data.BatchUpdatePresentationRequest' -Property @{Requests = $requests}
+
+        $presentation = Get-GSDriveFile -FileId $PresentationId
+        $PresentationUrl = $presentation.WebViewLink
+    }
+    Process {
+        foreach ($item in $Update) {
+            $requestType = ($item.psobject.Properties | Where-Object {$_.Value}).Name
+            Write-Verbose "Adding Request of type $requestType to Request Body"
+            $body.Requests.Add($item)
+        }
+    }
+    End {
+        try {
+            $request = $service.Presentations.BatchUpdate($body, $PresentationId)
+            Write-Verbose "Updating Presentation '$PresentationId' for user '$User'"
+            $request.Execute() | Add-Member -MemberType NoteProperty -Name 'User' -Value $User -PassThru | Add-Member -MemberType NoteProperty -Name 'PresentationUrl' -Value $PresentationUrl -PassThru
+            if ($Launch) {
+                Write-Verbose "Launching Presentation at $PresentationUrl"
+                Start-Process $PresentationUrl
+            }
+        } catch {
+            if ($ErrorActionPreference -eq 'Stop') {
+                $PSCmdlet.ThrowTerminatingError($_)
+            } else {
+                Write-Error $_
+            }
+        }
+    }
+}

--- a/PSGSuite/Public/Slides/Edit-GSPresentation.ps1
+++ b/PSGSuite/Public/Slides/Edit-GSPresentation.ps1
@@ -30,6 +30,11 @@ function Edit-GSPresentation {
     $newSlide | Edit-GSPresentation -PresentationID $ID #Will add one new slide at the end of the Presentation
     Edit-GSPresentation -PresentationID $ID -Update $newSlide,$newSlide #Will execute the newslide request twice, adding two new slides to the end of the Presentation
 
+    .NOTES
+    Executing multiple updates at once ensures the updates happen atomically, as one action.
+    If there is a problem with one of the updates, none of them will be executed.
+    If you wanted updates to happen individually, you would need to call this command multiple times, once per Update.
+
     #>
     [OutputType('Google.Apis.Slides.v1.Data.BatchUpdatePresentationResponse')]
     [cmdletbinding()]

--- a/PSGSuite/Public/Slides/Get-GSPresentation.ps1
+++ b/PSGSuite/Public/Slides/Get-GSPresentation.ps1
@@ -1,0 +1,81 @@
+﻿function Get-GSPresentation {
+    <#
+    .SYNOPSIS
+    Retrieves a Presentation
+
+    .DESCRIPTION
+    Retrieves a Presentation, in the form of a Google.Apis.Slides.v1.Data.Presentation object representing the presentation
+
+    .PARAMETER PresentationId
+    The unique Id of the Presentation
+
+    .PARAMETER User
+    The primary email of the user that has at least View rights to the target Presentation
+
+    Defaults to the AdminEmail user
+
+    .PARAMETER Launch
+    If $true, opens the Presentation Url in your default browser
+
+    .OUTPUTS
+    Google.Apis.Slides.v1.Data.Presentation
+    An overview of the properties of a Presentation are available here: https://developers.google.com/slides/reference/rest/v1/presentations
+
+    .EXAMPLE
+    $presentation = Get-GSPresentation -PresentationID $ID
+
+    #>
+    [OutputType('Google.Apis.Slides.v1.Data.Presentation')]
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory = $true, ValueFromPipeline = $true, Position = 0)]
+        [String]
+        $PresentationId,
+        [parameter(Mandatory = $false)]
+        [Alias('Owner', 'PrimaryEmail', 'UserKey', 'Mail')]
+        [string]
+        $User = $Script:PSGSuite.AdminEmail,
+        [parameter(Mandatory = $false)]
+        [Alias('Open')]
+        [Switch]
+        $Launch
+    )
+    begin {
+        if ($User -ceq 'me') {
+            $User = $Script:PSGSuite.AdminEmail
+        } elseif ($User -notlike "*@*.*") {
+            $User = "$($User)@$($Script:PSGSuite.Domain)"
+        }
+        $serviceParams = @{
+            Scope       = 'https://www.googleapis.com/auth/drive'
+            ServiceType = 'Google.Apis.Slides.v1.SlidesService'
+            User        = $User
+        }
+        $service = New-GoogleService @serviceParams
+    }
+
+    process {
+        try {
+            $request = $service.Presentations.Get($PresentationId)
+            Write-Verbose "Getting Presentation '$PresentationId' for user '$User'"
+            $request.Execute() | Add-Member -MemberType NoteProperty -Name 'User' -Value $User -PassThru | Add-Member -MemberType NoteProperty -Name 'PresentationUrl' -Value $PresentationUrl -PassThru
+            if ($Launch) {
+                $presentation = Get-GSDriveFile -FileId $PresentationId
+                $PresentationUrl = $presentation.WebViewLink
+                Write-Verbose "Launching Presentation at $PresentationUrl"
+                Start-Process $PresentationUrl
+            }
+        } catch {
+            if ($ErrorActionPreference -eq 'Stop') {
+                $PSCmdlet.ThrowTerminatingError($_)
+            } else {
+                Write-Error $_
+            }
+        }
+    }
+    end {
+
+    }
+
+
+}

--- a/PSGSuite/Public/Slides/New-GSPresentationUpdateRequest.ps1
+++ b/PSGSuite/Public/Slides/New-GSPresentationUpdateRequest.ps1
@@ -35,6 +35,7 @@
     #>
     [OutputType('Google.Apis.Slides.v1.Data.Request')]
     [CmdletBinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Does not change any state')]
     param (
         # Parameter help description
         [Parameter(Mandatory = $true, Position = 1, ValueFromPipelineByPropertyName = $true)]

--- a/PSGSuite/Public/Slides/New-GSPresentationUpdateRequest.ps1
+++ b/PSGSuite/Public/Slides/New-GSPresentationUpdateRequest.ps1
@@ -1,0 +1,108 @@
+﻿function New-GSPresentationUpdateRequest {
+    <#
+    .SYNOPSIS
+    Creates an Update Request to be used with Edit-GSPresentation
+
+    .DESCRIPTION
+    Creates an Update Request to be used with Edit-GSPresentation. Does the hard work of creating a "Google.Apis.Slides.v1.Data.$($RequestType)Request"
+    and generating a 'Google.Apis.Slides.v1.Data.Request' from it.
+
+    .PARAMETER RequestType
+    The type of update request, as described here: https://developers.google.com/slides/reference/rest/v1/presentations/request
+    Will dynamically validate RequestType based on request types supported by the Slides API library
+
+    .PARAMETER RequestProperties
+    The properties for the specified RequestType, as described here: https://developers.google.com/slides/reference/rest/v1/presentations/request
+    These properties must be strictly formatted to exactly match the parameters for the given request.
+
+    .OUTPUTS
+    Google.Apis.Slides.v1.Data.Request
+
+    .EXAMPLE
+    $newSlide = New-GSSlideUpdateRequest -RequestType CreateSlide -RequestProperties @{}
+    This will create a request to create a new slide at the end of the document with a uniquely generatd ObjectId.
+    The slide will be created with no layout.
+
+    $moveSlideProperties = @{slideObjectIds = @($slideToMove.ObjectId); insertionIndex=0}
+    $moveSlide = New-GSPresentationUpdateRequest -RequestType UpdateSlidesPosition -RequestProperties $moveSlideProperties
+    This will move the slide specified by $slideToMove to the beggining of the Presentation.
+    Note here that even though we're only moving a single slide, slideObjectIds is still set as an array, but with only a single element.
+
+    These Request objects can then be used to update a presentation using Edit-GSPresentation
+    Edit-GSPresentation -PresentationID $ID -Update $newSlide,$moveSlide
+    This will create a new slide at the end, then move the earlier specified slide to the beggining of the Presentation
+
+    #>
+    [OutputType('Google.Apis.Slides.v1.Data.Request')]
+    [CmdletBinding()]
+    param (
+        # Parameter help description
+        [Parameter(Mandatory = $true, Position = 1, ValueFromPipelineByPropertyName = $true)]
+        [hashtable]
+        $RequestProperties
+    )
+
+    DynamicParam {
+        # Instead of hardcoding each Request Type into a validate set, or simply passing any value as the request type,
+        # we will look at all the properites of a Data.Request (other than Etag) and assign that as the validate set.
+        # This will ensure that if new request types are added, this function will automatically support them, and they will be available for auto complete
+        $requests = ((New-Object 'Google.Apis.Slides.v1.Data.Request').psobject.Properties | Where-Object Name -ne Etag).Name
+        $attributes = New-Object System.Management.Automation.ParameterAttribute
+        $attributes.Mandatory = $true
+        $attributes.Position = 0
+        $attributes.ValueFromPipelineByPropertyName = $true
+        $attributeCollection = New-Object System.Collections.ObjectModel.Collection[System.Attribute]
+        $attributeCollection.Add($attributes)
+        $validateSetAttribute = New-Object System.Management.Automation.ValidateSetAttribute($requests)
+        $attributeCollection.Add($validateSetAttribute)
+
+        $dynParam1 = New-Object System.Management.Automation.RuntimeDefinedParameter("RequestType", [string], $attributeCollection)
+
+        $paramDictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
+        $paramDictionary.Add("RequestType", $dynParam1)
+        $paramDictionary
+
+    }
+    begin {
+
+    }
+    process {
+        try {
+            $RequestType = $PSBoundParameters['RequestType'] #Because of the Dynamic Parameters, this variable won't be automatically created like a regular parameter
+
+            # Requests that take an array of data require the data to be in a Generic.List (and will throw an unclear error if an array is used).
+            # However this can be cumbersome to construct in PowerShell, and will not automatically cast from a simple array.
+            # This will look through all the properties of the request, find any that are simple arrays,
+            # and convert them to a Generic.List of the appropriate type before creating the request object.
+            $correctedRequest = @{}
+            Write-Verbose "Processing RequestType $RequestType with RequestProperties $($RequestProperties | ConvertTo-Json -Compress)"
+            foreach ($key in $RequestProperties.keys) {
+                if ($RequestProperties[$key] -is 'System.Array') {
+                    $type = $RequestProperties[$key][0].GetType().FullName
+                    Write-Verbose "Converting $key to Generic.List of type $type"
+                    $obj = New-Object System.Collections.Generic.List[$type]
+                    foreach ($item in $RequestProperties[$key]) {
+                        $obj.Add($item)
+                    }
+                    $correctedRequest[$key] = $obj
+                } else {
+                    Write-Verbose "Adding $key to Request as-is"
+                    $correctedRequest[$key] = $RequestProperties[$key]
+                }
+            }
+            Write-Verbose ("Generating new Request Google.Apis.Slides.v1.Data.$RequestType" + "Request")
+            $request = New-Object ("Google.Apis.Slides.v1.Data.$RequestType" + "Request") -Property $correctedRequest
+            Write-Verbose "Generating new Google.Apis.Slides.v1.Data.Request"
+            New-Object Google.Apis.Slides.v1.Data.Request -Property @{$RequestType = $request}
+        } catch {
+            if ($ErrorActionPreference -eq 'Stop') {
+                $PSCmdlet.ThrowTerminatingError($_)
+            } else {
+                Write-Error $_
+            }
+        }
+    }
+    end {
+
+    }
+}


### PR DESCRIPTION
Implements getting and editing a Presentation

I needed it, so I wrote it.  This partially implements #150.  It's not the full Presentations API.  It's essentially just presentations.batchUpdate and presentations.get, leaving presentations.create, presentations.pages.get, and presentations.pages.getThumbnail to implement.

This also ended up being fairly low level, basically just serving as a wrapper around the API.  Unlike some of the other PSGSuite functions, this requires a fair amount of knowledge of how the API functions.

# Three new functions:
## Get-GSPresentation
This is pretty self-explanatory, it gets the presentation object, raw (it's not doing anything like the GSheet commands that translate the sheet into a data structure useful in PowerShell.  I don't think any kind of transformation would be universally useful, so getting the object is the best we can do.
## Edit-GSPresentation
This is what will make the edit to the slide.  It takes a set of Updates (either as an array passed to the parameter, or via Pipeline) and will execute them against the given presentations.  This uses batchUpdate, and when multiple Updates are sent as a single request, they are completed atomically.  While in other places this module uses batchUpdate to do a single update, I thought the atomicity was valuable here so I wrote this function such that it would take advantage of that fact.  But what is an Update you ask? Well...
## New-GSPresentationUpdateRequest
Updates are made with Requests.  Specifically there's a Requests object, and each Requests object has over 40 properties, for each type of Request.  A Request can only have one of these Requests specified.  Then the batchUpdate submits all the Requests at once.  To generate a request, you have to understand the API to know how to make your change.  I'll use `CreateSlide` as an example, because it's the simples.

`CreateSlide` (like all request types) request a `CreateSlideRequest`.  Once that `CreateSlideRequest` is created, it is attached to the `Request`.  This will validate that request you're creating exists, using Dynamic Parameters.  It means you can tab-complete through all the request types, and if a new request type is added, it will automatically be supported.

The properties for a `CreateSlideRequest` are simple, and can actually work with no properties, but it still requires an empty hashtable.   So to generate an update request for a new blank slide at the end of a presentation (any presentation, the request is not necessarily tied to a specific Spreadsheet) I'd run this command:
```powershell
$newSlide = New-GSPresentationUpdateRequest -RequestType CreateSlide -RequestProperties @{}
```
This can then be used with `Edit-GSPresentation` to actually make the change:
```powershell
$result = Edit-GSPresentation -PresentationId $ID -Update $newslide
```
Some of the request types require arrays of data (even for a single input) and the library expects them to be Generic Lists.  Instead of requiring the user to know what type of Generic List to construct and _how_ to construct a Generic List, I've added code to this that will do it for you, so for something like moving a slide with `UpdateSlidesPosition` you would create the request like this:
```powershell
$moveSlideProperties = @{slideObjectIds = @($slideToMove.ObjectId); insertionIndex=0}
$moveSlide = New-GSPresentationUpdateRequest -RequestType UpdateSlidesPosition -RequestProperties $moveSlideProperties
```
On the backend, this will detect if one of the parameters of the request is an array, and if so, make a new Generic List of the type of the first object (all arrays require the same object type) and then inserts each entry into List.

This part of the code abstracts the .Net implementation of the library, making the behavior much more like the API as described in Google's Documentation.

-------------------------
These generic functions let you fully utilize the API to edit presentations, though in a few cases the API requires special .Net objects to make the request.  For example, a `ReplaceAllText` request requires a SubstringMatchCriteria object, which means you need to run something like `New-Object Google.Apis.Slides.v1.Data.SubstringMatchCriteria`, that part isn't currently abstracted by this code.  Additional functions could easily be written that would generate this type of object without needing to know the underlying .Net object names.  In most cases these objects a fairly simple, for example creating a SubstringMatchCriteria requires 2 properties, a boolean of case sensitivity and the text to search for that will be replaced.

These generic functions could also be used as backing for more update-specific functions.  A New-GSPresentationSlide function with optional parameters objectId, insertionIndex, slideLayoutReference, and a placeholderIdMappings (the last two requiring custom objects, so since those objects aren't used anywhere else but in a new slide request, they can be created all within a single function)

I have been able to use all these myself so they've been tested in that capacity, but I'm not adding any new tests, because I'm not sure what I would be testing here, as you can see looking at the code there's very little "logic" to these functions to test for.

Per discussion in #275 around the User parameter and the pipeline, I've tried to be thoughtful about what can be received over the pipeline.  Specifically I've removed the User flag from being received from the pipeline by name.  All 3 functions do support pipelining.  For Get-GSPresentation you can pipe in presentation Ids, for Edit-GSPresentation you can pipe in your update requests, and for New-GSPresentationUpdateRequest you can pipe in custom objects, each containing a valid RequestType and valid RequestProperties for that RequestType.

I also see this is the first use of the `Edit` verb in this project, but it seemed far more appropriate than anything like Update or Set for modifying a presentation, but I'm open to other thoughts on that.