### PR TITLE
Update mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ site_url: 'https://psgsuite.io'
 # Repository
 repo_name: 'scrthq/PSGSuite'
 repo_url: 'https://github.com/scrthq/PSGSuite'
+edit_uri: 'edit/main/docs'
 
 # Copyright
 copyright: 'Copyright &copy; 2015 - 2019 Nate Ferrell'


### PR DESCRIPTION
Since the default branch has been renamed to main, the "edit" links on the docs are no longer correct.  Mkdocs assumes an edit uri of 'edit/master/docs' for Github repos if none is specified, so this will set it to to the new default branch.
https://www.mkdocs.org/user-guide/configuration/#edit_uri