### PR TITLE
Bugfix - missing Error variable

### DIFF
--- a/PSGSuite/Public/Delegation/Remove-GSGmailDelegate.ps1
+++ b/PSGSuite/Public/Delegation/Remove-GSGmailDelegate.ps1
@@ -59,6 +59,7 @@
                 Write-Verbose "Successfully removed delegate access for user '$User's inbox for delegate '$Delegate'"
             }
             catch {
+                $origError = $_
                 if ($ErrorActionPreference -eq 'Stop') {
                     $PSCmdlet.ThrowTerminatingError($origError)
                 }


### PR DESCRIPTION
$origError is never populated therefor the error that comes out is not helpful.